### PR TITLE
Fixed error in functions ex. 4 howodd

### DIFF
--- a/05-Bash-Programming.Rmd
+++ b/05-Bash-Programming.Rmd
@@ -1777,7 +1777,7 @@ howodd 42 6 7 9 33
 ```
 
 ```
-## .40
+## .60
 ```
 
 ```{r, engine='bash', eval=FALSE}


### PR DESCRIPTION
howodd 42 6 7 9 33
3 of the 5 arguments are odd. result should be 0.60, not 0.40